### PR TITLE
Fix/vercel install dev deps

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,7 @@ This guide addresses common frontend deployment issues and provides solutions fo
 
 - Updated `vercel.json` with proper monorepo support
 - Added security headers
-- Improved build/install commands using `npm ci --include=dev` to ensure devDependencies (TypeScript, Vite) are available during builds
+- Improved build/install commands using `NPM_CONFIG_PRODUCTION=false npm ci` to ensure devDependencies (TypeScript, Vite) are available during builds (compatible with older npm versions)
 - Added redirects for API routes
 
 ### 4. **Package Scripts Enhanced**
@@ -45,7 +45,7 @@ This guide addresses common frontend deployment issues and provides solutions fo
 
 ```bash
 # Vercel will run these commands automatically:
-cd frontend && npm ci --include=dev && npm run build
+cd frontend && NPM_CONFIG_PRODUCTION=false npm ci && npm run build
 ```
 
 ### Option 2: Docker Deployment

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,7 @@ This guide addresses common frontend deployment issues and provides solutions fo
 
 - Updated `vercel.json` with proper monorepo support
 - Added security headers
-- Improved build command using `npm ci` instead of `npm install`
+- Improved build/install commands using `npm ci --include=dev` to ensure devDependencies (TypeScript, Vite) are available during builds
 - Added redirects for API routes
 
 ### 4. **Package Scripts Enhanced**
@@ -45,7 +45,7 @@ This guide addresses common frontend deployment issues and provides solutions fo
 
 ```bash
 # Vercel will run these commands automatically:
-cd frontend && npm ci && npm run build
+cd frontend && npm ci --include=dev && npm run build
 ```
 
 ### Option 2: Docker Deployment

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,8 +45,11 @@ This guide addresses common frontend deployment issues and provides solutions fo
 
 ```bash
 # Vercel will run these commands automatically:
-cd frontend && NPM_CONFIG_PRODUCTION=false npm ci && npm run build
+cd frontend && NPM_CONFIG_PRODUCTION=false npm ci
+cd frontend && npm run build
 ```
+
+> Note: installation and build are separated to avoid redundant installs; Vercel persists `node_modules` between steps.
 
 ### Option 2: Docker Deployment
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=8.3.0"
   },
   "scripts": {
     "dev": "vite",

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "cd frontend && npm ci && npm run build",
+  "buildCommand": "cd frontend && npm ci --include=dev && npm run build",
   "outputDirectory": "frontend/dist",
-  "installCommand": "cd frontend && npm ci",
+  "installCommand": "cd frontend && npm ci --include=dev",
   "framework": null,
   "rewrites": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "cd frontend && npm ci --include=dev && npm run build",
+  "buildCommand": "cd frontend && NPM_CONFIG_PRODUCTION=false npm ci && npm run build",
   "outputDirectory": "frontend/dist",
-  "installCommand": "cd frontend && npm ci --include=dev",
+  "installCommand": "cd frontend && NPM_CONFIG_PRODUCTION=false npm ci",
   "framework": null,
   "rewrites": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd frontend && NPM_CONFIG_PRODUCTION=false npm ci && npm run build",
+  "buildCommand": "cd frontend && npm run build",
   "outputDirectory": "frontend/dist",
   "installCommand": "cd frontend && NPM_CONFIG_PRODUCTION=false npm ci",
   "framework": null,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ensure devDependencies installed during Vercel builds using `npm ci --include=dev`

- Add Node >=18 engine requirement to frontend package.json

- Update build and install commands in vercel.json configuration

- Update deployment documentation with improved build command details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vercel Build Process"] -->|"npm ci --include=dev"| B["Install Dependencies"]
  B -->|"Include devDeps"| C["TypeScript & Vite Available"]
  C -->|"npm run build"| D["Successful Build"]
  E["Node Engine Constraint"] -->|">=18"| F["package.json"]
  F -->|"Enforced"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vercel.json</strong><dd><code>Add devDependencies flag to Vercel install commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vercel.json

<ul><li>Updated <code>buildCommand</code> to use <code>npm ci --include=dev</code> instead of <code>npm ci</code><br> <li> Updated <code>installCommand</code> to use <code>npm ci --include=dev</code> instead of <code>npm ci</code><br> <li> Ensures devDependencies like TypeScript and Vite are available during <br>Vercel builds</ul>


</details>


  </td>
  <td><a href="https://github.com/KunjShah95/AETHER-AI/pull/19/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Node >=18 engine requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/package.json

<ul><li>Added <code>engines</code> field specifying Node >=18 requirement<br> <li> Enforces minimum Node version for frontend development and deployment</ul>


</details>


  </td>
  <td><a href="https://github.com/KunjShah95/AETHER-AI/pull/19/files#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DEPLOYMENT.md</strong><dd><code>Update deployment docs with improved build commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DEPLOYMENT.md

<ul><li>Updated build command documentation to include <code>--include=dev</code> flag<br> <li> Clarified that devDependencies (TypeScript, Vite) are ensured during <br>builds<br> <li> Updated example command in Option 1 section</ul>


</details>


  </td>
  <td><a href="https://github.com/KunjShah95/AETHER-AI/pull/19/files#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

